### PR TITLE
Added Language translate component + updated startview

### DIFF
--- a/src/components/LanguageSwitcher.vue
+++ b/src/components/LanguageSwitcher.vue
@@ -1,0 +1,42 @@
+<template>
+    <button class="language-switcher" @click="switchLanguage">
+      {{ lang === 'en' ? 'Switch to Swedish' : 'Switch to English' }}
+    </button>
+  </template>
+  
+  <script>
+  export default {
+    name: "LanguageSwitcher",
+    data() {
+      return {
+        lang: localStorage.getItem("lang") || "en", // Language preference
+      };
+    },
+    methods: {
+      switchLanguage() {
+        this.lang = this.lang === "en" ? "sv" : "en";
+        localStorage.setItem("lang", this.lang);
+        this.$emit("language-changed", this.lang); // Emit an event when the language changes
+      },
+    },
+  };
+  </script>
+  
+  <style scoped>
+  .language-switcher {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+  }
+  .language-switcher:hover {
+    background-color: #0056b3;
+  }
+  </style>
+  

--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="frontpage">
-    <!-- Button to toggle language -->
-    <button class="language-switcher" v-on:click="switchLanguage">
-      {{ lang === 'en' ? 'Switch to Swedish' : 'Switch to English' }}
-    </button>
+    <!-- Language switcher component -->
+    <LanguageSwitcher @language-changed="updateLanguage" />
 
     <!-- Title of the game -->
     <h1 class="game-title">Pregame<sup>2</sup></h1>
@@ -29,12 +27,14 @@
 <script>
 import io from "socket.io-client"; // Import WebSocket library
 import PinInput from "@/components/PinInput.vue"; // Import PinInput component
+import LanguageSwitcher from "@/components/LanguageSwitcher.vue"; // Import LanguageSwitcher component
 const socket = io("localhost:3000"); // Initialize WebSocket connection
 
 export default {
   name: "StartView",
   components: {
     PinInput,
+    LanguageSwitcher,
   },
   data: function () {
     return {
@@ -50,10 +50,9 @@ export default {
     socket.emit("getUILabels", this.lang);
   },
   methods: {
-    // Toggle between English and Swedish
-    switchLanguage: function () {
-      this.lang = this.lang === "en" ? "sv" : "en";
-      localStorage.setItem("lang", this.lang);
+    // Update language when changed in LanguageSwitcher
+    updateLanguage(lang) {
+      this.lang = lang;
       socket.emit("getUILabels", this.lang);
     },
     // Show PIN entry form
@@ -87,23 +86,6 @@ export default {
   position: relative;
 }
 
-/* Button to switch languages */
-.language-switcher {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  font-size: 0.9rem;
-}
-.language-switcher:hover {
-  background-color: #0056b3;
-}
-
 /* Style for the game title */
 .game-title {
   font-size: 3rem;
@@ -129,8 +111,6 @@ export default {
   text-align: center;
   cursor: pointer;
 }
-
-/* Button hover effect */
 .btn:hover {
   background-color: #0056b3;
 }

--- a/src/views/StartView.vue
+++ b/src/views/StartView.vue
@@ -4,7 +4,7 @@
     <LanguageSwitcher @language-changed="updateLanguage" />
 
     <!-- Title of the game -->
-    <h1 class="game-title">Pregame<sup>2</sup></h1>
+    <h1 class="game-title">Pre(game)<sup>2</sup></h1>
 
     <!-- Show PIN input form if joinGameClicked is true -->
     <PinInput


### PR DESCRIPTION
This pull request refactors the language switcher functionality by creating a new `LanguageSwitcher` component and integrating it into the `StartView` component. The changes improve code modularity and maintainability by separating concerns.

Key changes include:

### New Component Addition:
* [`src/components/LanguageSwitcher.vue`](diffhunk://#diff-1568d5fa8b207848529cb01d7317d18f52780caf4433a42b734a5614ceb162adR1-R42): Created a new `LanguageSwitcher` component to handle language switching, including template, script, and styles.

### Integration in StartView:
* `src/views/StartView.vue`: 
  - Replaced the inline language switcher button with the new `LanguageSwitcher` component.
  - Imported the `LanguageSwitcher` component and registered it within the `components` object.
  - Updated the method to handle language change events from the `LanguageSwitcher` component.
  - Removed the old language switcher button styles and methods. [[1]](diffhunk://#diff-a980f8fde40ec6579095d88a4d5766f9b491246d66de09d8b22e0d81251b4af9L90-L106) [[2]](diffhunk://#diff-a980f8fde40ec6579095d88a4d5766f9b491246d66de09d8b22e0d81251b4af9L132-L133)