### PR TITLE
små färgändringar i create view + defualt camera pic visas alltid i backsteg

### DIFF
--- a/server/data/labels-en.json
+++ b/server/data/labels-en.json
@@ -68,7 +68,7 @@
 	"showEndResults": "SHOW RESULTS!",
 	"allResults": "ALL RESULTS",
 	"theMost": "THE MOST",
-	"startNewGame": "Start new game!",
+	"startNewGame": "End game!",
 	"skip": "Skip",
 
 

--- a/server/data/labels-sv.json
+++ b/server/data/labels-sv.json
@@ -67,7 +67,7 @@
 	"showEndResults": "VISA RESULTAT!",
 	"allResults": "ALLA RESULTAT",
 	"theMost": "GRUPPENS",
-	"startNewGame": "Starta nytt spel!",
+	"startNewGame": "Avsluta spel!",
 	"skip": "Skippa",
 
 "INSTRUCTIONS": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -212,7 +212,7 @@ button:hover {
 
 button.selected {
   background-color: rgb(255, 131, 203);
-  border: 2px solid white;
+  border: 0.25rem solid white;
 }
 
 button:disabled {

--- a/src/components/CameraComponent.vue
+++ b/src/components/CameraComponent.vue
@@ -209,13 +209,13 @@ img {
 }
 
 .camera-buttons button {
-  background-color: rgb(254, 78, 152); /* Darker pink */
+  background-color: rgb(252, 63, 173);
   min-width: 10rem;
-  border: solid 0.06rem rgb(160, 15, 75);
+  border: solid 0.06rem rgb(214, 25, 135);
 }
 
 .camera-buttons button:hover {
-  background-color: rgb(243, 41, 125); /* Darker hover effect */
+  background-color: rgb(214, 25, 135); /* Darker hover effect */
 }
 
 button {

--- a/src/components/CameraComponent.vue
+++ b/src/components/CameraComponent.vue
@@ -42,11 +42,11 @@ export default {
     uiLabels: {},
     disableSwitcher: {},
     isPictureTaken: {},
+    cameraState: {},
   },
   data: function () {
     return {
       avatar: null, // Ensure avatar is defined in the data
-      cameraState: false,
       stream: null, // The video stream to access the camera
       cameraPicIcon,
     };
@@ -65,7 +65,7 @@ export default {
       this.$emit("update:isPictureTaken", false);
       this.$emit("update:disableSwitcher", true);
       //this.isPictureTaken = false;
-      this.cameraState = true;
+      this.$emit("update:cameraState", true);
       //this.disableSwitcher = true;
 
       // Stop any existing camera stream before starting a new one, make sure always turned off
@@ -91,7 +91,7 @@ export default {
           alert(
             "Unable to access the camera. Please check your camera settings."
           );
-          this.cameraState = false; // Allow retry if error occurs
+          this.$emit("update:cameraState", false); // Allow retry if error occurs
         });
     },
 
@@ -106,7 +106,7 @@ export default {
       if (this.$refs.video) {
         this.$refs.video.srcObject = null; // Clear the video element source
       }
-      this.cameraState = false;
+      this.$emit("update:cameraState", false)
       this.$emit("update:disableSwitcher", false);
       //this.disableSwitcher = false;
     },
@@ -135,7 +135,7 @@ export default {
         console.log("Avatar captured");
         //console.log("Captured Avatar: ", this.avatar);
 
-        this.cameraState = false; // Disable camera actions
+        this.$emit("update:cameraState", false); // Disable camera actions
 
         // Stop the camera stream after capturing the image
         this.stopCamera();
@@ -209,12 +209,13 @@ img {
 }
 
 .camera-buttons button {
-  background-color: rgb(225, 95, 150); /* Darker pink */
+  background-color: rgb(254, 78, 152); /* Darker pink */
   min-width: 10rem;
+  border: solid 0.06rem rgb(160, 15, 75);
 }
 
 .camera-buttons button:hover {
-  background-color: rgb(205, 85, 140); /* Darker hover effect */
+  background-color: rgb(243, 41, 125); /* Darker hover effect */
 }
 
 button {

--- a/src/views/LobbyView.vue
+++ b/src/views/LobbyView.vue
@@ -60,7 +60,7 @@
           {{ this.uiLabels.back || "Back" }}
         </button>
 
-        <button
+        <button id="avatar-or-pic-button"
           v-on:click="chooseAvatar"
           v-if="!choseCustomAvatar"
           :disabled="disableSwitcher"
@@ -68,7 +68,7 @@
           {{ this.uiLabels.choosePreMadeAvatar || "Choose Pre-made Avatar" }}
         </button>
 
-        <button v-on:click="returnToPictureMode" v-if="choseCustomAvatar">
+        <button id="avatar-or-pic-button" v-on:click="returnToPictureMode" v-if="choseCustomAvatar">
           {{ this.uiLabels.takeAPictureInstead || "Take A Picture Instead" }}
         </button>
 
@@ -413,6 +413,16 @@ button:disabled {
 
 #submitNameButton:hover {
   background-color: rgb(219, 34, 142);
+}
+
+
+#avatar-or-pic-button {
+  background-color: rgb(254, 78, 152); /* Darker pink */
+  border: solid 0.06rem rgb(160, 15, 75);
+}
+
+#avatar-or-pic-button:hover {
+  background-color: rgb(243, 41, 125); /* Darker hover effect */
 }
 
 /* Style for the name input box */

--- a/src/views/LobbyView.vue
+++ b/src/views/LobbyView.vue
@@ -407,23 +407,17 @@ button:disabled {
 }
 
 /* Special styling for button: */
-#submitNameButton {
+#submitNameButton, #avatar-or-pic-button  {
   background-color: rgb(252, 63, 173);
+  border: 0.06rem solid rgb(218, 48, 147);
 }
 
-#submitNameButton:hover {
+#submitNameButton:hover, #avatar-or-pic-button:hover {
   background-color: rgb(219, 34, 142);
 }
 
 
-#avatar-or-pic-button {
-  background-color: rgb(254, 78, 152); /* Darker pink */
-  border: solid 0.06rem rgb(160, 15, 75);
-}
 
-#avatar-or-pic-button:hover {
-  background-color: rgb(243, 41, 125); /* Darker hover effect */
-}
 
 /* Style for the name input box */
 input[type="text"] {

--- a/src/views/LobbyView.vue
+++ b/src/views/LobbyView.vue
@@ -36,9 +36,11 @@
             v-model:isPictureTaken="isPictureTaken"
             :uiLabels="uiLabels"
             :disableSwitcher="disableSwitcher"
+            :cameraState="cameraState"
             @update:avatar="avatar = $event"
             @update:disableSwitcher="disableSwitcher = $event"
             @update:isPictureTaken="isPictureTaken = $event"
+            @update:cameraState="cameraState = $event"
           />
         </div>
         <div v-if="choseCustomAvatar">
@@ -49,7 +51,6 @@
             @update:isPictureTaken="isPictureTaken = $event"
             @avatar-selected="handleAvatarSelection"
           />
-          <!-- @update:avatar="avatar = $event" -->
         </div>
       </div>
 
@@ -159,6 +160,7 @@ export default {
       //camera
       disableSwitcher: false, //connected to choose premade avatar button
       isPictureTaken: false,
+      cameraState: false,
 
       //leave poll lobby
       showModal: false,
@@ -252,7 +254,10 @@ export default {
     // Move to the previous step
     backStep: function () {
       if (this.step > 1) {
-        this.step--;
+        this.cameraState=false;
+        this.isPictureTaken=false;
+
+        this.step--;  
       }
     },
 
@@ -303,8 +308,6 @@ export default {
       if (this.participants.length >= 3) {
         this.atLeastThree = true;
       }
-
-     
 
       if (this.isAdmin) {
         localStorage.setItem("userId", this.userId);

--- a/src/views/PollView.vue
+++ b/src/views/PollView.vue
@@ -420,6 +420,11 @@ export default {
 
 #game-id-headline {
   color: rgb(252, 181, 212);
+  text-shadow: 
+    1px 1px 0 rgb(196, 0, 111),
+    -1px 1px 0 rgb(196, 0, 111),
+    1px -1px 0 rgb(196, 0, 111),
+    -1px -1px 0 rgb(196, 0, 111);
 
   position: sticky; /* Kan bli problem på mobiltelefon */
   top: 3rem;

--- a/src/views/WaitingView.vue
+++ b/src/views/WaitingView.vue
@@ -499,6 +499,11 @@ input[type="text"] {
 
 #game-id-headline {
   color: rgb(252, 181, 212);
+  text-shadow: 
+    1px 1px 0 rgb(196, 0, 111),
+    -1px 1px 0 rgb(196, 0, 111),
+    1px -1px 0 rgb(196, 0, 111),
+    -1px -1px 0 rgb(196, 0, 111);
 
   position: fixed;
   top: 3rem;


### PR DESCRIPTION
Lite färg och förtydligande fix efter usability testning - mer färgändring kan behövas, create och lobby och waiting och poll

Default camera pic visas alltid vid baksteg, nu kan ej bild sparas som tagits (på gott och ont)